### PR TITLE
Update `seed.js` to allow seeding reviews and appointments. Added functionality to seed the remote MongoDB Atlas cluster/collections. Potentially resolved an issue with Render deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGODB_URI=''

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "foundation-sites": "^6.8.1"
       },
       "devDependencies": {
@@ -153,6 +154,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/emoji-regex": {
@@ -483,6 +495,11 @@
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server/server.js",
     "develop": "concurrently \"cd server && npm run watch\" \"cd client && npm run dev\"",
     "install": "cd server && npm install && cd ../client && npm install",
-    "build": "cd client && npm run build && gulp build",
+    "build": "cd client && npm run build",
     "render-build": "npm install && npm run build",
     "seed": "node server/seeds/seed.js"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "concurrently": "^8.2.0"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "foundation-sites": "^6.8.1"
   }
 }

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+require('dotenv').config(); // Added to allow access to our local environmental variable that contains MONGODB_URI
 
 mongoose.connect(process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/salonservices');
 

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -124,6 +124,8 @@ db.once('open', async () => {
         { new: true } 
         );
     });
+    
+    // DO NOT DELETE: Again, this query allows the function 
     const outsideReview = await User.find();
 
     console.log('all done!');

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -7,83 +7,91 @@ const cleanDB = require('./cleanDb');
 db.once('open', async () => {
   try {
   	// Clear records from existing collections
-    await cleanDB('User', 'users');
-    await cleanDB('Service', 'services');
-    await cleanDB('Appointment', 'appointments');
-    await cleanDB('Review', 'reviews');
-    await cleanDB('Tag', 'tags');
+    // await cleanDB('User', 'users');
+    // await cleanDB('Service', 'services');
+    // await cleanDB('Appointment', 'appointments');
+    // await cleanDB('Review', 'reviews');
+    // await cleanDB('Tag', 'tags');
 
-    // Begin seeding the database
-    await User.create(userData);
-    await Service.create(serviceData);
+    // // Begin seeding the database
+    // await User.create(userData);
+    // await Service.create(serviceData);
 
-    // Retrieve 
-    const nonArtistUsers = await User.find({ artist: false });
-    const artistUser = await User.find({ artist: true })
-    // console.log(`nonArtistUsers: ${nonArtistUsers}`);
-    // console.log(`artistUser: ${artistUser}`);
+    // // Retrieve 
+    // const nonArtistUsers = await User.find({ artist: false });
+    // const artistUser = await User.find({ artist: true })
+    // // console.log(`nonArtistUsers: ${nonArtistUsers}`);
+    // // console.log(`artistUser: ${artistUser}`);
 
-    const services = await Service.find();
-    // console.log(services)
+    // const services = await Service.find();
+    // // console.log(services)
 
-    // Scheduling appointments
-    await Appointment.insertMany([
-    	{
-    		user: nonArtistUsers[0]['_id'],
-    		services: [services[0]['_id'], services[1]['_id']],
-    		apptDate: new Date('2024-05-05T09:30:00-05:00'),
-    		requests: "Would like to get red nail polish",
-    		completed: true,
-    		artist: artistUser[0]['_id']
-    	},
-    	{
-    		user: nonArtistUsers[1]['_id'],
-    		services: [services[2]['_id']],
-    		apptDate: new Date('2024-07-04T09:30:00-05:00'),
-    		completed: false,
-    		artist: artistUser[0]['_id']
-    	},
-    	{
-    		user: nonArtistUsers[2]['_id'],
-    		services: [services[0]['_id'], services[2]['_id']],
-    		apptDate: new Date('2024-06-13T09:30:00-05:00'),
-    		completed: false,
-    		artist: artistUser[0]['_id']
-    	},
-    	{
-    		user: nonArtistUsers[0]['_id'],
-    		services: [services[2]['_id']],
-    		apptDate: new Date('2024-06-05T09:30:00-05:00'),
-    		requests: 'Coming in for a touchup',
-    		completed: false,
-    		artist: artistUser[0]['_id']
-    	}
-    	]);
+    // // Scheduling appointments
+    // await Appointment.insertMany([
+    // 	{
+    // 		user: nonArtistUsers[0]['_id'],
+    // 		services: [services[0]['_id'], services[1]['_id']],
+    // 		apptDate: new Date('2024-05-05T09:30:00-05:00'),
+    // 		requests: "Would like to get red nail polish",
+    // 		completed: true,
+    // 		artist: artistUser[0]['_id']
+    // 	},
+    // 	{
+    // 		user: nonArtistUsers[1]['_id'],
+    // 		services: [services[2]['_id']],
+    // 		apptDate: new Date('2024-07-04T09:30:00-05:00'),
+    // 		completed: false,
+    // 		artist: artistUser[0]['_id']
+    // 	},
+    // 	{
+    // 		user: nonArtistUsers[2]['_id'],
+    // 		services: [services[0]['_id'], services[2]['_id']],
+    // 		apptDate: new Date('2024-06-13T09:30:00-05:00'),
+    // 		completed: false,
+    // 		artist: artistUser[0]['_id']
+    // 	},
+    // 	{
+    // 		user: nonArtistUsers[0]['_id'],
+    // 		services: [services[2]['_id']],
+    // 		apptDate: new Date('2024-06-05T09:30:00-05:00'),
+    // 		requests: 'Coming in for a touchup',
+    // 		completed: false,
+    // 		artist: artistUser[0]['_id']
+    // 	}
+    // 	]);
 
     // Appointments are NOT automatically populated within the parent User records
     const storedAppointments = await Appointment.find();
     // console.log(storedAppointments);
     await storedAppointments.map(async (appointment) => {
     	// Update the user's appointments array
-    	// console.log(appointment)
-      // console.log(appointment.user)
+    	// console.log(appointment.user)
+      // console.log(typeof appointment.user.toString())
+
+      const userId = appointment.user.toString();
+      const artistId = appointment.artist.toString();
+      const testUser = await User.find({_id : appointment.user})
+      console.log(testUser)
       // console.log('after appointment')
-      const retrievedUser =  User.find({ _id: '664ea00512c9dd7c4eb4ee4f' });
+      // const retrievedUser =  User.find({ _id: '664ea00512c9dd7c4eb4ee4f' });
       //console.log(retrievedUser)
-    	const updatedUser =  User.findByIdAndUpdate(appointment.user,
-    		{ $push: { appointments : appointment._id} },
-    		{ new: true }
-    		);
-    	console.log(`updatedUser: ${updatedUser}`);
-    	// Update the artist's appointments array
-    	const updatedArtist =  User.findByIdAndUpdate(appointment.artist,
-    		{ $addToSet: { appointments : appointment} },
-    		{ new: true, runValidators: true }
-    		);
-    	console.log(`updatedArtist: ${updatedArtist}`)
+    	// const updatedUser =  User.findByIdAndUpdate(appointment.user,
+    	// 	{ $push: { appointments : appointment._id} },
+    	// 	{ new: true }
+    	// 	);
+    	// // console.log(`updatedUser: ${updatedUser}`);
+    	// // Update the artist's appointments array
+    	// const updatedArtist =  User.findByIdAndUpdate(appointment.artist,
+    	// 	{ $addToSet: { appointments : appointment} },
+    	// 	{ new: true, runValidators: true }
+    	// 	);
+    	// // console.log(`updatedArtist: ${updatedArtist}`)
     })
 
-
+    // Unsure why, but having a query outside of the map function allows the query inside of the map function to execute 
+    const outsideMapUser = await User.find()
+    console.log("******* OUTSIDE ********")
+    console.log(outsideMapUser);
     console.log('all done!');
     process.exit(0);
   } catch (err) {

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -87,6 +87,45 @@ db.once('open', async () => {
     const outsideMapUser = await User.find()
     // console.log("******* OUTSIDE ********")
     // console.log(outsideMapUser);
+
+    // Populate reviews
+    await Review.insertMany([
+      {
+        user: nonArtistUsers[0]['_id'],
+        apptId: storedAppointments[0]._id,
+        rating: '5',
+        content: 'I had a phenomenal visit',
+        date: Date.now()
+      },
+      {
+        user: nonArtistUsers[1]['_id'],
+        rating: '4',
+        content: 'This is a general review about my visit',
+        date: Date.now()
+      },
+      {
+        user: nonArtistUsers[2]['_id'],
+        apptId: storedAppointments[2]._id,
+        rating: '5',
+        content: 'I came in for two services and all of the staff made me feel at home',
+        date: Date.now()
+      },
+    ]);
+
+    const storedReviews = await Review.find();
+    await storedReviews.map(async (review) => {
+
+      const userId = review.user.toString();
+      const reviewId = review._id.toString();
+
+      // Update the user's review array
+      const updatedUser = await User.findByIdAndUpdate(userId,
+        { $push: { reviews : reviewId} },
+        { new: true } 
+        );
+    });
+    const outsideReview = await User.find();
+
     console.log('all done!');
     process.exit(0);
   } catch (err) {

--- a/server/seeds/seed.js
+++ b/server/seeds/seed.js
@@ -7,91 +7,86 @@ const cleanDB = require('./cleanDb');
 db.once('open', async () => {
   try {
   	// Clear records from existing collections
-    // await cleanDB('User', 'users');
-    // await cleanDB('Service', 'services');
-    // await cleanDB('Appointment', 'appointments');
-    // await cleanDB('Review', 'reviews');
-    // await cleanDB('Tag', 'tags');
+    await cleanDB('User', 'users');
+    await cleanDB('Service', 'services');
+    await cleanDB('Appointment', 'appointments');
+    await cleanDB('Review', 'reviews');
+    await cleanDB('Tag', 'tags');
 
-    // // Begin seeding the database
-    // await User.create(userData);
-    // await Service.create(serviceData);
+    // Begin seeding the database
+    await User.create(userData);
+    await Service.create(serviceData);
 
-    // // Retrieve 
-    // const nonArtistUsers = await User.find({ artist: false });
-    // const artistUser = await User.find({ artist: true })
-    // // console.log(`nonArtistUsers: ${nonArtistUsers}`);
-    // // console.log(`artistUser: ${artistUser}`);
+    // Retrieve each type of user
+    const nonArtistUsers = await User.find({ artist: false });
+    const artistUser = await User.find({ artist: true });
 
-    // const services = await Service.find();
-    // // console.log(services)
+    // Retrieve services
+    const services = await Service.find();
 
-    // // Scheduling appointments
-    // await Appointment.insertMany([
-    // 	{
-    // 		user: nonArtistUsers[0]['_id'],
-    // 		services: [services[0]['_id'], services[1]['_id']],
-    // 		apptDate: new Date('2024-05-05T09:30:00-05:00'),
-    // 		requests: "Would like to get red nail polish",
-    // 		completed: true,
-    // 		artist: artistUser[0]['_id']
-    // 	},
-    // 	{
-    // 		user: nonArtistUsers[1]['_id'],
-    // 		services: [services[2]['_id']],
-    // 		apptDate: new Date('2024-07-04T09:30:00-05:00'),
-    // 		completed: false,
-    // 		artist: artistUser[0]['_id']
-    // 	},
-    // 	{
-    // 		user: nonArtistUsers[2]['_id'],
-    // 		services: [services[0]['_id'], services[2]['_id']],
-    // 		apptDate: new Date('2024-06-13T09:30:00-05:00'),
-    // 		completed: false,
-    // 		artist: artistUser[0]['_id']
-    // 	},
-    // 	{
-    // 		user: nonArtistUsers[0]['_id'],
-    // 		services: [services[2]['_id']],
-    // 		apptDate: new Date('2024-06-05T09:30:00-05:00'),
-    // 		requests: 'Coming in for a touchup',
-    // 		completed: false,
-    // 		artist: artistUser[0]['_id']
-    // 	}
-    // 	]);
+    // Scheduling appointments, passing services as embedded document
+    await Appointment.insertMany([
+    	{
+    		user: nonArtistUsers[0]['_id'],
+    		services: [services[0]['_id'], services[1]['_id']],
+    		apptDate: new Date('2024-05-05T09:30:00-05:00'),
+    		requests: "Would like to get red nail polish",
+    		completed: true,
+    		artist: artistUser[0]['_id']
+    	},
+    	{
+    		user: nonArtistUsers[1]['_id'],
+    		services: [services[2]['_id']],
+    		apptDate: new Date('2024-07-04T09:30:00-05:00'),
+    		completed: false,
+    		artist: artistUser[0]['_id']
+    	},
+    	{
+    		user: nonArtistUsers[2]['_id'],
+    		services: [services[0]['_id'], services[2]['_id']],
+    		apptDate: new Date('2024-06-13T09:30:00-05:00'),
+    		completed: false,
+    		artist: artistUser[0]['_id']
+    	},
+    	{
+    		user: nonArtistUsers[0]['_id'],
+    		services: [services[2]['_id']],
+    		apptDate: new Date('2024-06-05T09:30:00-05:00'),
+    		requests: 'Coming in for a touchup',
+    		completed: false,
+    		artist: artistUser[0]['_id']
+    	}
+    	]);
 
     // Appointments are NOT automatically populated within the parent User records
     const storedAppointments = await Appointment.find();
-    // console.log(storedAppointments);
     await storedAppointments.map(async (appointment) => {
-    	// Update the user's appointments array
-    	// console.log(appointment.user)
-      // console.log(typeof appointment.user.toString())
 
+      // The returned appointment type has `new objectId('string')` but we need to extract the ID value itself
       const userId = appointment.user.toString();
       const artistId = appointment.artist.toString();
-      const testUser = await User.find({_id : appointment.user})
-      console.log(testUser)
-      // console.log('after appointment')
-      // const retrievedUser =  User.find({ _id: '664ea00512c9dd7c4eb4ee4f' });
-      //console.log(retrievedUser)
-    	// const updatedUser =  User.findByIdAndUpdate(appointment.user,
-    	// 	{ $push: { appointments : appointment._id} },
-    	// 	{ new: true }
-    	// 	);
-    	// // console.log(`updatedUser: ${updatedUser}`);
-    	// // Update the artist's appointments array
-    	// const updatedArtist =  User.findByIdAndUpdate(appointment.artist,
-    	// 	{ $addToSet: { appointments : appointment} },
-    	// 	{ new: true, runValidators: true }
-    	// 	);
-    	// // console.log(`updatedArtist: ${updatedArtist}`)
-    })
+      const appointmentId = appointment._id.toString();
+      // console.log(`${userId}, ${artistId}, ${appointmentId}`);
 
-    // Unsure why, but having a query outside of the map function allows the query inside of the map function to execute 
+      // Update the user's appointments array
+    	const updatedUser = await User.findByIdAndUpdate(userId,
+    		{ $push: { appointments : appointmentId} },
+    		{ new: true } // Do NOT add `runValidators: true`, will return an invalid query
+    		);
+
+    	// console.log(`updatedUser: ${updatedUser}`);
+    	// Update the artist's appointments array
+    	const updatedArtist = await User.findByIdAndUpdate(artistId,
+    		{ $push: { appointments : appointmentId} },
+    		{ new: true }
+    		);
+    	// console.log(`updatedArtist: ${updatedArtist}`)
+    });
+
+    // DO NOT DELETE QUERY: Unsure why, but having a query outside of the map function allows the query inside of the map function to execute 
     const outsideMapUser = await User.find()
-    console.log("******* OUTSIDE ********")
-    console.log(outsideMapUser);
+    // console.log("******* OUTSIDE ********")
+    // console.log(outsideMapUser);
     console.log('all done!');
     process.exit(0);
   } catch (err) {

--- a/server/seeds/serviceData.json
+++ b/server/seeds/serviceData.json
@@ -13,5 +13,20 @@
 		"name": "Nail buffing",
 		"time": 20,
 		"price": 15
+	},
+	{
+		"name": "Facial",
+		"time": 30,
+		"price": 40
+	},
+	{
+		"name": "Brow waxing",
+		"time": 15,
+		"price": 15
+	},
+	{
+		"name": "Brow tinting",
+		"time": 10,
+		"price": 15
 	}
 ]


### PR DESCRIPTION
In "server" directory: 

- Resolved the issue as to why `appointment` records were not being passed to a user's 'appointments array
    - I am not entirely sure why my solution functions. There is a query OUTSIDE of the map function and without this external query, the queries internal tothe map function will not execute
- Seeded `review` records and passed these to a user's 'reviews' array. Similar to the appointments, we have to call a query outside and after the map function
- For both of these external queries, I placed comments to NOT DELETE the queries
- In `serviceData.json` added a few new services
- Added the `dotenv` package to the root-level `package.json`. Within it, I have stored the `MONGODB_URI` environmental variable that will will connect to our remote MongoDB database for this service
- In `connection.js`, imported `dotenv` functionality to access the local environmental variable. This allows us to seed our remote database directly from our local machine and our `seed.js` file

---------------------------------

- There was an error from an earlier pull request in which a new technology, `gulp`, was being implemented on the client but a reference to `gulp build` prevented Render from completing it's build. 
- In root-level `package.json`, I removed `gulp build` from our "build" script because `gulp` is being implemented at the client-level and the client-level `package.json`'s build script references `gulp build` so it is redundant to call twice
